### PR TITLE
[Podspec] Use vendored_libraries

### DIFF
--- a/Intercom.podspec
+++ b/Intercom.podspec
@@ -15,10 +15,8 @@ Pod::Spec.new do |s|
 
   s.platform          = :ios, '7.0'
   s.source_files      = 'Intercom/Intercom.h'
-  s.preserve_paths    = 'Intercom/libIntercom.a'
+  s.vendored_libraries = ['Intercom/libIntercom.a']
   s.requires_arc      = true
-  
+
   s.frameworks        = 'Foundation', 'UIKit', 'Security', "SystemConfiguration", "MobileCoreServices", "ImageIO", "AVFoundation", "QuartzCore", "CoreGraphics"
-  s.xcconfig          = { 'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/Intercom/Intercom/libIntercom.a"', 
-                          'LIBRARY_SEARCH_PATHS' => '$(PODS_ROOT)/Intercom/Intercom' }
 end


### PR DESCRIPTION
[`$PODS_ROOT`](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#breaking-1) is deprecated and you should be using `vendored_libraries` instead of `$PODS_ROOT` with `LIBRARY_SEARCH_PATHS` and `OTHER_LDFLAGS`.

The current podspec would break if it was used by a user from a directory with a space, because the path for `LIBRARY_SEARCH_PATHS` is not escaped if the value of `$PODS_ROOT` was to contain a space. This would also cause issues if the podspec was used via `pod 'Intercom', :path => '..etc...'` due to the path of Intercom inside `$PODS_ROOT` would be different.

**Note**: _I have not tested this other than with `pod lib lint`, please ensure that your own tests still pass._
