### PR TITLE
Missing manual step causes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Add the Intercom pod into your Podfile and run `pod install`.
 
 1. [Download Intercom for iOS](https://github.com/intercom/intercom-ios/archive/master.zip) and extract the zip.
 2. Go to your Xcode project's "General" settings. Drag `Intercom.framework` to the "Embedded Binaries" section. Make sure "Copy items if needed" is selected and click Finish.
-3. Create a new "Run Script Phase" in your app’s target’s "Build Phases" and paste the following snippet in the script text field:
+3. Build your app once.
+4. Create a new "Run Script Phase" in your app’s target’s "Build Phases" and paste the following snippet in the script text field:
 
         bash "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Intercom.framework/strip-frameworks.sh"
 This step is required to work around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) when archiving universal binaries.


### PR DESCRIPTION
When manually installing intercom and adding the custom `Run Script Phase`, there is a step missing which causes the app to not compile.

The error says that the `strip-frameworks.sh` file cannot be found.

```
bash: /Users/Allan/Library/Developer/Xcode/DerivedData/XXXX/Build/Products/Debug-iphoneos/XXX.app/Frameworks/Intercom.framework/strip-frameworks.sh: No such file or directory
```

This problem references [a closed issue](https://github.com/intercom/intercom-ios/issues/152#issuecomment-235437768) but I think the documentation never got updated 🚀 
