### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -2,12 +2,12 @@
 
 The example apps provide a basic demo of Intercom's iOS SDK. Further details on the SDK's API can be found [here](https://github.com/intercom/intercom-ios/blob/master/Intercom.framework/Headers/Intercom.h)
 
-##Objective C
+## Objective C
 1. Go to **/Sample-ObjC** and open **Sample-ObjC.xcodeproj**
 2. Set your iOS **API key** and **App ID** at the top of `ITCAppDelegate.m`
 3. Build and Run 🎉
 
-##Swift
+## Swift
 1. Go to **/Sample-Swift** and open **Sample-Swift.xcodeproj**
 2. Set your iOS **API key** and **App ID** at the top of `AppDelegate.swift`
 3. Build and Run 🙌

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ When installing Intercom, you'll need to make sure that you have a `NSPhotoLibra
 
 This is [required by Apple](https://developer.apple.com/library/content/qa/qa1937/_index.html) for all apps that access the photo library. It is necessary when installing Intercom due to the image upload functionality. Users will be prompted for the photo library permission only when they tap the image upload button.
 
-##Example app
+## Example app
 There is an example app provided [here](https://github.com/intercom/intercom-ios/tree/master/Examples) for both Objective-C and Swift.
 
-##Setup and Configuration
+## Setup and Configuration
 
 * Our [installation guide](https://developers.intercom.com/docs/ios-installation) contains full setup and initialisation instructions.
 * Read ["Configuring Intercom for iOS"](https://developers.intercom.com/docs/ios-configuration).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
