### PR TITLE
WIP: Demonstrate memory and logging off issues

### DIFF
--- a/Examples/Sample-SwiftUI/iOS/SceneDelegate.swift
+++ b/Examples/Sample-SwiftUI/iOS/SceneDelegate.swift
@@ -10,7 +10,8 @@ import Intercom
 
 let INTERCOM_APP_ID = "<#YOUR APP ID#>"
 let INTERCOM_API_KEY = "<#YOUR API KEY#>"
-let emailKey = "email"
+let hashKey = "hash"
+let userIdKey = "userid"
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -28,8 +29,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         #endif
         
         let defaults = UserDefaults.standard
-        if let email = defaults.string(forKey: emailKey) {
-            Intercom.registerUser(withEmail: email)
+        if let hash = defaults.string(forKey: hashKey) {
+            Intercom.setUserHash(hash)
+        }
+        if let userId = defaults.string(forKey: userIdKey) {
+            Intercom.registerUser(withUserId: userId)
         }
     }
 

--- a/Examples/Sample-SwiftUI/iOS/Views/ContentView.swift
+++ b/Examples/Sample-SwiftUI/iOS/Views/ContentView.swift
@@ -10,8 +10,9 @@ import Intercom
 
 struct ContentView: View {
 
-    @State private var email = UserDefaults.standard.string(forKey: emailKey) ?? ""
-    @State private var loggedIn = UserDefaults.standard.string(forKey: emailKey) != nil
+    @State private var userHash = UserDefaults.standard.string(forKey: hashKey) ?? ""
+    @State private var userId = UserDefaults.standard.string(forKey: userIdKey) ?? ""
+    @State private var loggedIn = UserDefaults.standard.string(forKey: userIdKey) != nil
 
     var body: some View {
         VStack(alignment: .center, spacing: 80) {
@@ -20,9 +21,9 @@ struct ContentView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(maxWidth: 200)
             if !loggedIn {
-                LoggedOutView(email: $email, loggedIn:$loggedIn)
+                LoggedOutView(userHash: $userHash, userId: $userId, loggedIn: $loggedIn)
             } else {
-                LoggedInView(email: $email, loggedIn:$loggedIn)
+                LoggedInView(userHash: $userHash, userId: $userId, loggedIn: $loggedIn)
             }
         }.padding()
     }

--- a/Examples/Sample-SwiftUI/iOS/Views/LoggedInView.swift
+++ b/Examples/Sample-SwiftUI/iOS/Views/LoggedInView.swift
@@ -10,7 +10,8 @@ import Intercom
 
 struct LoggedInView: View {
     
-    @Binding var email: String
+    @Binding var userHash: String
+    @Binding var userId: String
     @Binding var loggedIn: Bool
 
     var body: some View {
@@ -18,7 +19,7 @@ struct LoggedInView: View {
             VStack(spacing:15) {
                 Text("Logged in as:")
                     .titleStyle()
-                Text(email)
+                Text(userId)
             }
             VStack(spacing:15) {
                 StylizedButton("Open Messenger", action: openMessenger)
@@ -38,7 +39,7 @@ struct LoggedInView: View {
     }
     
     func openArticle() {
-        Intercom.presentArticle(<#ARTICLE_ID#>)
+        Intercom.presentArticle("article placeholder")
     }
     
     func logoutOfIntercom() {
@@ -46,18 +47,21 @@ struct LoggedInView: View {
         Intercom.logout()
         
         let defaults = UserDefaults.standard
-        defaults.removeObject(forKey: emailKey)
+        defaults.removeObject(forKey: hashKey)
+        defaults.removeObject(forKey: userIdKey)
         loggedIn = false
-        email = ""
+        userHash = ""
+        userId = ""
     }
     
 }
 
 struct LoggedInView_Previews: PreviewProvider {
-    @State static private var email = "myemail@email.com"
+    @State static private var userHash = "my user hmac"
+    @State static private var userId = "my user id"
     @State static private var loggedIn = true
     
     static var previews: some View {
-        LoggedInView(email: $email, loggedIn: $loggedIn)
+        LoggedInView(userHash: $userHash, userId: $userId, loggedIn: $loggedIn)
     }
 }

--- a/Examples/Sample-SwiftUI/iOS/Views/LoggedOutView.swift
+++ b/Examples/Sample-SwiftUI/iOS/Views/LoggedOutView.swift
@@ -10,33 +10,39 @@ import Intercom
 
 struct LoggedOutView: View {
     
-    @Binding var email: String
+    @Binding var userHash: String
+    @Binding var userId: String
     @Binding var loggedIn: Bool
 
     var body: some View {
         VStack(spacing: 25) {
-            StylizedTextField(title: "Email", text: $email, onCommit: loginToIntercom)
+            StylizedTextField(title: "User HMAC", text: $userHash, onCommit: loginToIntercom)
+                .frame(maxWidth: 350)
+            StylizedTextField(title: "User ID", text: $userId, onCommit: loginToIntercom)
                 .frame(maxWidth: 350)
             StylizedButton("Login", action: loginToIntercom)
-                .disabled(email.isEmpty)
+                .disabled(userHash.isEmpty && userId.isEmpty)
         }
     }
     
     func loginToIntercom() {
         // Start tracking the user with Intercom
-        Intercom.registerUser(withEmail: email)
+        Intercom.setUserHash(userHash)
+        Intercom.registerUser(withUserId: userId)
         
         let defaults = UserDefaults.standard
-        defaults.set(email, forKey: emailKey)
+        defaults.set(userHash, forKey: hashKey)
+        defaults.set(userId, forKey: userIdKey)
         loggedIn = true
     }
 }
 
 struct LoggedOutView_Previews: PreviewProvider {
-    @State static private var email = "myemail@email.com"
+    @State static private var userHash = "my user hmac"
+    @State static private var userId = "my user id"
     @State static private var loggedIn = true
 
     static var previews: some View {
-        LoggedOutView(email: $email, loggedIn: $loggedIn)
+        LoggedOutView(userHash: $userHash, userId: $userId, loggedIn: $loggedIn)
     }
 }


### PR DESCRIPTION
This is to demonstrate 2 issues found with integrating the Intercom iOS SDK into a native iOS app:

1. Memory leaking. With every 'presentMessenger' method call, memory keeps increasing and does not release 'js.intercomcdn.com - card-fallback.html', even after logging out the user. You can check this by using the WebInspector tool in Safari.
<img width="795" alt="Screen Shot 2021-07-29 at 2 39 50 PM" src="https://user-images.githubusercontent.com/26751106/127547881-334d6563-f577-4b05-a370-d154a64d5feb.png">
To reproduce, simply log in with a user HMAC and ID and open/close the messenger multiple times. You will see the list of card-fallbacks increasing.

2. Not completely logging off users. After a user has been registered, after logging off and providing a failed log-in attempt, the Intercom messenger will still show the previous logged in user name and data (on the header card).
To reproduce, log in with a valid hmac and user id and log out. Log in again with any dummy data and open the Intercom messenger. You will see that although the user cannot be registered, the name still shows the previous logged in user.
